### PR TITLE
feat(math): implement `GreateCommonDivisor()` logic

### DIFF
--- a/tachyon/math/base/BUILD.bazel
+++ b/tachyon/math/base/BUILD.bazel
@@ -79,6 +79,11 @@ tachyon_cc_library(
 )
 
 tachyon_cc_library(
+    name = "number_theory",
+    hdrs = ["number_theory.h"],
+)
+
+tachyon_cc_library(
     name = "rational_field",
     hdrs = ["rational_field.h"],
     deps = [
@@ -158,6 +163,7 @@ tachyon_cc_unittest(
         "egcd_unittest.cc",
         "field_unittest.cc",
         "groups_unittest.cc",
+        "number_theory_unittest.cc",
         "rational_field_unittest.cc",
         "semigroups_unittest.cc",
         "sign_unittest.cc",
@@ -168,6 +174,7 @@ tachyon_cc_unittest(
         ":bit_iterator",
         ":egcd",
         ":groups",
+        ":number_theory",
         ":rational_field",
         ":sign",
         ":simd_int",

--- a/tachyon/math/base/number_theory.h
+++ b/tachyon/math/base/number_theory.h
@@ -1,0 +1,55 @@
+//==================================================================================
+// BSD 2-Clause License
+//
+// Copyright (c) 2014-2023, NJIT, Duality Technologies Inc. and other
+// contributors
+//
+// All rights reserved.
+//
+// Author TPOC: contact@openfhe.org
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//==================================================================================
+
+#ifndef TACHYON_MATH_BASE_NUMBER_THEORY_H_
+#define TACHYON_MATH_BASE_NUMBER_THEORY_H_
+
+namespace tachyon::math {
+
+// TODO(Insun35): support GCD logic for native int type.
+template <typename BigIntTy>
+BigIntTy GreatestCommonDivisor(const BigIntTy& a, const BigIntTy& b) {
+  BigIntTy m_a = a;
+  BigIntTy m_b = b;
+  while (m_b != BigIntTy::Zero()) {
+    BigIntTy tmp = m_b;
+    m_b = m_a % m_b;
+    m_a = tmp;
+  }
+  return m_a;
+}
+
+}  // namespace tachyon::math
+
+#endif  // TACHYON_MATH_BASE_NUMBER_THEORY_H_

--- a/tachyon/math/base/number_theory_unittest.cc
+++ b/tachyon/math/base/number_theory_unittest.cc
@@ -1,0 +1,36 @@
+#include "tachyon/math/base/number_theory.h"
+
+#include "gtest/gtest.h"
+
+#include "tachyon/math/base/big_int.h"
+
+namespace tachyon::math {
+
+TEST(NumberTheoryTest, GreatestCommonDivisorSmallNumber) {
+  BigInt<1> a = BigInt<1>(10403);
+  BigInt<1> b = BigInt<1>(103);
+  BigInt<1> c = GreatestCommonDivisor(a, b);
+
+  BigInt<1> expected_result = BigInt<1>(103);
+
+  EXPECT_EQ(expected_result, c);
+
+  a = BigInt<1>(1048576);
+  b = BigInt<1>(4096);
+
+  c = GreatestCommonDivisor(a, b);
+
+  EXPECT_EQ(b, c);
+}
+
+TEST(NumberTheoryTest, GreatestCommonDivisorBigNumber) {
+  BigInt<2> a = *BigInt<2>::FromDecString("883035439563027");
+  BigInt<2> b = *BigInt<2>::FromDecString("3042269397984931");
+  BigInt<2> c = GreatestCommonDivisor(a, b);
+
+  BigInt<2> expected_result = BigInt<2>(1);
+
+  EXPECT_EQ(expected_result, c);
+}
+
+}  // namespace tachyon::math


### PR DESCRIPTION
This PR implements Number Theory logics using in OpenFHE.

Number Theory contains:
- GreatestCommonDivisor
- (WIP)

See https://github.com/openfheorg/openfhe-development/blob/94fd76a1d965cfde13f2a540d78ce64146fc2700/src/core/include/math/nbtheory.h
